### PR TITLE
SMP-1268: Remove cpu from resources.limits

### DIFF
--- a/src/ff-pushpin-service/values.yaml
+++ b/src/ff-pushpin-service/values.yaml
@@ -40,7 +40,6 @@ pushpin:
     imagePullSecrets: []
   resources:
     limits:
-      cpu: 1
       memory: 2048Mi
     requests:
       cpu: 1
@@ -60,7 +59,6 @@ pushpinworker:
     runAsNonRoot: true
   resources:
     limits:
-      cpu: 1
       memory: 2048Mi
     requests:
       cpu: 1

--- a/src/ff-service/values.yaml
+++ b/src/ff-service/values.yaml
@@ -105,7 +105,6 @@ service:
 
 resources:
   limits:
-    cpu: 1
     memory: 2048Mi
   requests:
     cpu: 1

--- a/src/ff/values.yaml
+++ b/src/ff/values.yaml
@@ -50,7 +50,6 @@ ff-pushpin-service:
       digest: ""
     resources:
       limits:
-        cpu: 1
         memory: 2048Mi
       requests:
         cpu: 1
@@ -69,7 +68,6 @@ ff-pushpin-service:
       runAsNonRoot: true
     resources:
       limits:
-        cpu: 1
         memory: 2048Mi
       requests:
         cpu: 1
@@ -204,7 +202,6 @@ ff-service:
 
   resources:
     limits:
-      cpu: 1
       memory: 2048Mi
     requests:
       cpu: 1


### PR DESCRIPTION
Refer: [SMP 1268: Remove CPU from the resource limits in Kubernetes Manifests](https://harness.atlassian.net/wiki/spaces/~7120205e3981db61bd4dcc8068ae7262d845f7/pages/edit-v2/21404484175)