### PR TITLE
updated image tags for ff-server and ff-pushpin

### DIFF
--- a/src/ff-pushpin-service/Chart.yaml
+++ b/src/ff-pushpin-service/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.1"
+appVersion: "0.0.2"
 dependencies:
   - name: harness-common
     version: 1.x.x

--- a/src/ff-pushpin-service/values.yaml
+++ b/src/ff-pushpin-service/values.yaml
@@ -52,7 +52,7 @@ pushpinworker:
     repository: harness/ff-pushpin-worker-signed
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "1.945.0"
+    tag: "1.0.11"
     digest: ""
     imagePullSecrets: []
   securityContext:

--- a/src/ff-service/Chart.yaml
+++ b/src/ff-service/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.1"
+appVersion: "0.0.2"
 dependencies:
   - name: harness-common
     version: 1.x.x

--- a/src/ff-service/templates/job.yaml
+++ b/src/ff-service/templates/job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: ff-service-db-migrate-1-945-{{ lower ( randAlphaNum 6 ) }}
+  name: ff-service-db-migrate-1-1073-{{ lower ( randAlphaNum 6 ) }}
   namespace: {{ .Release.Namespace }}
   annotations:
   labels:
@@ -72,7 +72,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: ff-service-timescale-db-migrate-1-945-{{ lower ( randAlphaNum 6 ) }}
+  name: ff-service-timescale-db-migrate-1-1073-{{ lower ( randAlphaNum 6 ) }}
   namespace: {{ .Release.Namespace }}
   annotations:
   labels:

--- a/src/ff-service/values.yaml
+++ b/src/ff-service/values.yaml
@@ -36,7 +36,7 @@ image:
   repository: harness/ff-server-signed
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.945.0"
+  tag: "1.1073.0"
   digest: ""
   imagePullSecrets: []
 
@@ -44,7 +44,7 @@ jobs:
   postgres_migration:
     image:
       registry: docker.io
-      tag: "1.945.0"
+      tag: "1.1073.0"
       repository: harness/ff-postgres-migration-signed
       pullPolicy: Always
       digest: ""
@@ -52,7 +52,7 @@ jobs:
   timescaledb_migrate:
     image:
       registry: docker.io
-      tag: "1.945.0"
+      tag: "1.1073.0"
       repository: harness/ff-timescale-migration-signed
       pullPolicy: Always
       digest: ""

--- a/src/ff/values.yaml
+++ b/src/ff/values.yaml
@@ -62,7 +62,7 @@ ff-pushpin-service:
       repository: harness/ff-pushpin-worker-signed
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
-      tag: "1.945.0"
+      tag: "1.1073.0"
       digest: ""
     securityContext:
       runAsUser: 65534
@@ -138,21 +138,21 @@ ff-service:
     repository: harness/ff-server-signed
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "1.945.0"
+    tag: "1.1073.0"
     digest: ""
 
   jobs:
     postgres_migration:
       image:
         registry: docker.io
-        tag: "1.945.0"
+        tag: "1.1073.0"
         repository: harness/ff-postgres-migration-signed
         pullPolicy: Always
         digest: ""
     timescaledb_migrate:
       image:
         registry: docker.io
-        tag: "1.945.0"
+        tag: "1.1073.0"
         repository: harness/ff-timescale-migration-signed
         pullPolicy: Always
         digest: ""


### PR DESCRIPTION
Brings ff-server image tags inline with prod to 1.1073.0  and ff-pushpin-worker to 1.0.11